### PR TITLE
feat: change the use mode and fix the existing problems

### DIFF
--- a/.changeset/sixty-trees-deliver.md
+++ b/.changeset/sixty-trees-deliver.md
@@ -1,0 +1,8 @@
+---
+'@zyrong/json-parser': minor
+---
+
+The coderange range is changed to end+1, Easier to use `string.slice(start, end)`
+visitor.isSimpleNode/isComplexNode change to export
+Fix the problem that the empty key node through visitor.get ('') cannot be obtained
+Change the original visitor.get("") to visitor.get() to obtain the visitor.body node

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ console.log(visitor.body) // 根node
   "key": null,
   "type": "object",
   "valueRange": {
-    "end": 45,
+    "end": 46,
     "start": 0
   },
   "parent": null,
@@ -29,11 +29,11 @@ console.log(visitor.body) // 根node
       "type": "array",
       "key": "array",
       "keyRange": {
-        "end": 11,
+        "end": 12,
         "start": 7
       },
       "valueRange": {
-        "end": 41,
+        "end": 42,
         "start": 15
       },
       "parent": ["Circular"],
@@ -44,7 +44,7 @@ console.log(visitor.body) // 根node
           "type": "string",
           "value": "string",
           "valueRange": {
-            "end": 29,
+            "end": 30,
             "start": 24
           }
         },
@@ -54,7 +54,7 @@ console.log(visitor.body) // 根node
           "type": "number",
           "value": "123",
           "valueRange": {
-            "end": 35,
+            "end": 36,
             "start": 33
           }
         }
@@ -66,13 +66,13 @@ console.log(visitor.body) // 根node
 
 
 // 字符串索引路径访问node
-console.log(visitor.get('array.0').value.code); // output: 'string'
+console.log(visitor.get('array.0').value); // output: 'string'
 
 // 访问不存在的node，返回undefined
-console.log(visitor.get('xxx').value.code);     // output: undefined
+console.log(visitor.get('xxx').value);     // output: undefined
 
 // 返回根node
-console.log(visitor.get('') === visitor.body);  // output: true
+console.log(visitor.get() === visitor.body);  // output: true
 ```  
 <br/>
 
@@ -135,7 +135,7 @@ const range = {
   start: 103,
   end: 109
 }
-const selectedString = packageJson.slice(range.start, range.end+1) // ts-node
+const selectedString = packageJson.slice(range.start, range.end) // ts-node
 // -------------------
 
 
@@ -143,7 +143,7 @@ import jsonParse from '@zyrong/json-parser'
 const visitor = jsonParse(packageJson)
 const node = visitor.get('dependencies')
 const depRange = node.valueRange
-if(range.start > depRange.start && range.end < depRange.end){
+if(range.start >= depRange.start && range.end <= depRange.end){
   console.log(selectedString+'在dependencies的范围内')
 }else{
   console.log(selectedString+'不在dependencies的范围内')

--- a/__tests__/__snapshots__/index.test.ts.snap
+++ b/__tests__/__snapshots__/index.test.ts.snap
@@ -9,134 +9,148 @@ Object {
     Object {
       "key": "empty_string",
       "keyRange": Object {
-        "end": 16,
+        "end": 17,
         "start": 5,
       },
       "parent": [Circular],
       "type": "string",
       "value": "",
       "valueRange": Object {
-        "end": 20,
+        "end": 21,
         "start": 21,
       },
     },
     Object {
       "key": "string",
       "keyRange": Object {
-        "end": 32,
+        "end": 33,
         "start": 27,
       },
       "parent": [Circular],
       "type": "string",
       "value": "string",
       "valueRange": Object {
-        "end": 42,
+        "end": 43,
         "start": 37,
       },
     },
     Object {
       "key": "\\\\\\"",
       "keyRange": Object {
-        "end": 50,
+        "end": 51,
         "start": 49,
       },
       "parent": [Circular],
       "type": "string",
       "value": "\\\\\\"",
       "valueRange": Object {
-        "end": 55,
+        "end": 56,
         "start": 54,
+      },
+    },
+    Object {
+      "key": "",
+      "keyRange": Object {
+        "end": 62,
+        "start": 62,
+      },
+      "parent": [Circular],
+      "type": "string",
+      "value": "",
+      "valueRange": Object {
+        "end": 65,
+        "start": 65,
       },
     },
     Object {
       "key": "number",
       "keyRange": Object {
-        "end": 67,
-        "start": 62,
+        "end": 77,
+        "start": 71,
       },
       "parent": [Circular],
       "type": "number",
       "value": "0",
       "valueRange": Object {
-        "end": 71,
-        "start": 71,
+        "end": 80,
+        "start": 80,
       },
     },
     Object {
       "key": "null",
       "keyRange": Object {
-        "end": 80,
-        "start": 77,
+        "end": 90,
+        "start": 86,
       },
       "parent": [Circular],
       "type": "null",
       "value": "null",
       "valueRange": Object {
-        "end": 87,
-        "start": 84,
+        "end": 97,
+        "start": 93,
       },
     },
     Object {
       "key": "false",
       "keyRange": Object {
-        "end": 97,
-        "start": 93,
+        "end": 107,
+        "start": 102,
       },
       "parent": [Circular],
       "type": "boolean",
       "value": "false",
       "valueRange": Object {
-        "end": 104,
-        "start": 100,
+        "end": 114,
+        "start": 109,
       },
     },
     Object {
       "key": "true",
       "keyRange": Object {
-        "end": 113,
-        "start": 110,
+        "end": 123,
+        "start": 119,
       },
       "parent": [Circular],
       "type": "boolean",
       "value": "true",
       "valueRange": Object {
-        "end": 120,
-        "start": 117,
+        "end": 130,
+        "start": 126,
       },
     },
     Object {
       "key": "array",
       "keyRange": Object {
-        "end": 130,
-        "start": 126,
+        "end": 140,
+        "start": 135,
       },
       "parent": [Circular],
       "properties": Array [],
       "type": "array",
       "valueRange": Object {
-        "end": 135,
-        "start": 134,
+        "end": 144,
+        "start": 143,
       },
     },
     Object {
       "key": "object",
       "keyRange": Object {
-        "end": 146,
-        "start": 141,
+        "end": 156,
+        "start": 150,
       },
       "parent": [Circular],
       "properties": Array [],
       "type": "object",
       "valueRange": Object {
-        "end": 151,
-        "start": 150,
+        "end": 160,
+        "start": 159,
       },
     },
     Object {
       "key": "deep",
       "keyRange": Object {
-        "end": 160,
-        "start": 157,
+        "end": 170,
+        "start": 166,
       },
       "parent": [Circular],
       "properties": Array [
@@ -148,106 +162,106 @@ Object {
             Object {
               "key": "empty_string",
               "keyRange": Object {
-                "end": 190,
-                "start": 179,
+                "end": 200,
+                "start": 188,
               },
               "parent": [Circular],
               "type": "string",
               "value": "",
               "valueRange": Object {
-                "end": 194,
-                "start": 195,
+                "end": 204,
+                "start": 204,
               },
             },
             Object {
               "key": "string",
               "keyRange": Object {
-                "end": 210,
-                "start": 205,
+                "end": 220,
+                "start": 214,
               },
               "parent": [Circular],
               "type": "string",
               "value": "string",
               "valueRange": Object {
-                "end": 220,
-                "start": 215,
+                "end": 230,
+                "start": 224,
               },
             },
             Object {
               "key": "\\\\\\"",
               "keyRange": Object {
-                "end": 232,
-                "start": 231,
+                "end": 242,
+                "start": 240,
               },
               "parent": [Circular],
               "type": "string",
               "value": "\\\\\\"",
               "valueRange": Object {
-                "end": 237,
-                "start": 236,
+                "end": 247,
+                "start": 245,
               },
             },
             Object {
               "key": "number",
               "keyRange": Object {
-                "end": 253,
-                "start": 248,
+                "end": 263,
+                "start": 257,
               },
               "parent": [Circular],
               "type": "number",
               "value": "0",
               "valueRange": Object {
-                "end": 257,
-                "start": 257,
+                "end": 266,
+                "start": 266,
               },
             },
             Object {
               "key": "null",
               "keyRange": Object {
-                "end": 270,
-                "start": 267,
+                "end": 280,
+                "start": 276,
               },
               "parent": [Circular],
               "type": "null",
               "value": "null",
               "valueRange": Object {
-                "end": 277,
-                "start": 274,
+                "end": 287,
+                "start": 283,
               },
             },
             Object {
               "key": "false",
               "keyRange": Object {
-                "end": 291,
-                "start": 287,
+                "end": 301,
+                "start": 296,
               },
               "parent": [Circular],
               "type": "boolean",
               "value": "false",
               "valueRange": Object {
-                "end": 298,
-                "start": 294,
+                "end": 308,
+                "start": 303,
               },
             },
             Object {
               "key": "true",
               "keyRange": Object {
-                "end": 311,
-                "start": 308,
+                "end": 321,
+                "start": 317,
               },
               "parent": [Circular],
               "type": "boolean",
               "value": "true",
               "valueRange": Object {
-                "end": 318,
-                "start": 315,
+                "end": 328,
+                "start": 324,
               },
             },
           ],
           "type": "object",
           "valueRange": Object {
-            "end": 324,
-            "start": 170,
+            "end": 333,
+            "start": 179,
           },
         },
         Object {
@@ -262,8 +276,8 @@ Object {
               "type": "number",
               "value": "1",
               "valueRange": Object {
-                "end": 332,
-                "start": 332,
+                "end": 341,
+                "start": 341,
               },
             },
             Object {
@@ -273,8 +287,8 @@ Object {
               "type": "string",
               "value": "2",
               "valueRange": Object {
-                "end": 335,
-                "start": 335,
+                "end": 345,
+                "start": 344,
               },
             },
             Object {
@@ -284,8 +298,8 @@ Object {
               "type": "null",
               "value": "null",
               "valueRange": Object {
-                "end": 341,
-                "start": 338,
+                "end": 351,
+                "start": 347,
               },
             },
             Object {
@@ -295,8 +309,8 @@ Object {
               "type": "boolean",
               "value": "false",
               "valueRange": Object {
-                "end": 347,
-                "start": 343,
+                "end": 357,
+                "start": 352,
               },
             },
             Object {
@@ -306,15 +320,15 @@ Object {
               "type": "boolean",
               "value": "true",
               "valueRange": Object {
-                "end": 352,
-                "start": 349,
+                "end": 362,
+                "start": 358,
               },
             },
           ],
           "type": "array",
           "valueRange": Object {
-            "end": 353,
-            "start": 331,
+            "end": 362,
+            "start": 340,
           },
         },
         Object {
@@ -324,8 +338,8 @@ Object {
           "type": "number",
           "value": "1",
           "valueRange": Object {
-            "end": 360,
-            "start": 360,
+            "end": 369,
+            "start": 369,
           },
         },
         Object {
@@ -335,8 +349,8 @@ Object {
           "type": "string",
           "value": "2",
           "valueRange": Object {
-            "end": 363,
-            "start": 363,
+            "end": 373,
+            "start": 372,
           },
         },
         Object {
@@ -346,8 +360,8 @@ Object {
           "type": "null",
           "value": "null",
           "valueRange": Object {
-            "end": 369,
-            "start": 366,
+            "end": 379,
+            "start": 375,
           },
         },
         Object {
@@ -357,8 +371,8 @@ Object {
           "type": "boolean",
           "value": "false",
           "valueRange": Object {
-            "end": 375,
-            "start": 371,
+            "end": 385,
+            "start": 380,
           },
         },
         Object {
@@ -368,21 +382,21 @@ Object {
           "type": "boolean",
           "value": "true",
           "valueRange": Object {
-            "end": 380,
-            "start": 377,
+            "end": 390,
+            "start": 386,
           },
         },
       ],
       "type": "array",
       "valueRange": Object {
-        "end": 384,
-        "start": 164,
+        "end": 393,
+        "start": 173,
       },
     },
   ],
   "type": "object",
   "valueRange": Object {
-    "end": 386,
+    "end": 395,
     "start": 0,
   },
 }
@@ -412,7 +426,7 @@ Object {
       "type": "string",
       "value": "2",
       "valueRange": Object {
-        "end": 4,
+        "end": 5,
         "start": 4,
       },
     },
@@ -423,7 +437,7 @@ Object {
       "type": "null",
       "value": "null",
       "valueRange": Object {
-        "end": 10,
+        "end": 11,
         "start": 7,
       },
     },
@@ -434,7 +448,7 @@ Object {
       "type": "boolean",
       "value": "false",
       "valueRange": Object {
-        "end": 16,
+        "end": 17,
         "start": 12,
       },
     },
@@ -445,7 +459,7 @@ Object {
       "type": "boolean",
       "value": "true",
       "valueRange": Object {
-        "end": 21,
+        "end": 22,
         "start": 18,
       },
     },
@@ -466,7 +480,7 @@ Object {
   "type": "boolean",
   "value": "false",
   "valueRange": Object {
-    "end": 4,
+    "end": 5,
     "start": 0,
   },
 }
@@ -480,7 +494,7 @@ Object {
   "type": "null",
   "value": "null",
   "valueRange": Object {
-    "end": 3,
+    "end": 4,
     "start": 0,
   },
 }
@@ -508,7 +522,7 @@ Object {
   "type": "string",
   "value": "string",
   "valueRange": Object {
-    "end": 6,
+    "end": 7,
     "start": 1,
   },
 }

--- a/__tests__/fixtures/all.json
+++ b/__tests__/fixtures/all.json
@@ -2,6 +2,7 @@
   "empty_string": "",
   "string": "string",
   "\"":"\"",
+  "":"",
   "number": 0,
   "null": null,
   "false":false,

--- a/__tests__/visitor.test.ts
+++ b/__tests__/visitor.test.ts
@@ -1,6 +1,7 @@
-import jsonParse from '../src/index'
+import jsonParse, { isSimpleNode } from '../src/index'
 
 const json = `{
+  "": "empty_key",
   "object": {
     "2": 123,
     "b": "123",
@@ -16,6 +17,17 @@ if (!visitor) {
   throw new Error('parse error')
 }
 
+it('visitor.get body', () => {
+  const node = visitor.get()
+  expect(node).toBe(visitor.body)
+})
+
+it('visitor.get empty_key', () => {
+  const node = visitor.get("")
+  if (isSimpleNode(node)) {
+    expect(node.value).toBe("empty_key")
+  }
+})
 
 it('visitor.get Nonexistent node', () => {
   const node = visitor.get('object.1')
@@ -24,7 +36,7 @@ it('visitor.get Nonexistent node', () => {
 
 it('visitor.get StringPath base', () => {
   const node = visitor.get('object.b')
-  if (visitor.isSimpleNode(node)) {
+  if (isSimpleNode(node)) {
     expect(node.type).toBe('string')
     expect(node.value).toBe('123')
   } else {
@@ -34,7 +46,7 @@ it('visitor.get StringPath base', () => {
 
 it('visitor.get StringPath number', () => {
   const node = visitor.get('object.2')
-  if (visitor.isSimpleNode(node)) {
+  if (isSimpleNode(node)) {
     expect(node.type).toBe('number')
     expect(node.value).toBe('123')
   } else {
@@ -44,7 +56,7 @@ it('visitor.get StringPath number', () => {
 
 it('visitor.get StringPath emptyKey', () => {
   const node = visitor.get('object..c')
-  if (visitor.isSimpleNode(node)) {
+  if (isSimpleNode(node)) {
     expect(node.type).toBe('number')
     expect(node.value).toBe('123')
   } else {
@@ -54,7 +66,7 @@ it('visitor.get StringPath emptyKey', () => {
 
 it('visitor.get ArrayPath base', () => {
   let node = visitor.get(["object", "", "c"])
-  if (visitor.isSimpleNode(node)) {
+  if (isSimpleNode(node)) {
     expect(node.type).toBe('number')
     expect(node.value).toBe('123')
   } else {
@@ -64,7 +76,7 @@ it('visitor.get ArrayPath base', () => {
 
 it('visitor.get ArrayPath dotKey', () => {
   const node = visitor.get(["object", ".d"])
-  if (visitor.isSimpleNode(node)) {
+  if (isSimpleNode(node)) {
     expect(node.type).toBe('number')
     expect(node.value).toBe('123')
   } else {
@@ -74,7 +86,7 @@ it('visitor.get ArrayPath dotKey', () => {
 
 it('visitor.get stringPath Array', () => {
   const node = visitor.get("array.0")
-  if (visitor.isSimpleNode(node)) {
+  if (isSimpleNode(node)) {
     expect(node.type).toBe('string')
     expect(node.value).toBe('2')
   } else {

--- a/example/base.ts
+++ b/example/base.ts
@@ -1,6 +1,7 @@
-import jsonParse from "../src/index";
+import jsonParse, { isSimpleNode } from "../src/index";
 
 const json = `{
+  "": "empty_key",
   "empty_string": "",
   "string": "string",
   "number": 0,
@@ -30,8 +31,8 @@ try {
 
   if (visitor) {
     const node = visitor.get('deep.0.string')
-    if (visitor.isSimpleNode(node)) {
-      console.log(node.value.code);
+    if (isSimpleNode(node)) {
+      console.log(node.value);
     }
   }
 } catch (error) {

--- a/example/visitor.ts
+++ b/example/visitor.ts
@@ -1,4 +1,4 @@
-import jsonParse from "../src/index";
+import jsonParse, { isSimpleNode } from "../src/index";
 
 const json = `{
   "a": {
@@ -12,13 +12,13 @@ const visitor = jsonParse(json)
 if (visitor) {
   const node1 = visitor.get('a..b')
 
-  if (visitor.isSimpleNode(node1)) {
+  if (isSimpleNode(node1)) {
     console.log(node1.type === 'string');
     console.log(node1.value === '123');
   }
 
   const node2 = visitor.get(['a','.c'])
-  if (visitor.isSimpleNode(node2)) {
+  if (isSimpleNode(node2)) {
     console.log(node2.type === 'number');
     console.log(node2.value === '123');
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,6 @@
 import parse from './parser'
+
 export default parse
+export { parse }
+export { default as Visitor } from './visitor'
+export { CodeRange, isComplexNode, isSimpleNode } from './util'

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -220,7 +220,7 @@ export default function parse(json: string): Visitor | null {
     if (char === '"') {
       const string = getStringLiteral(json, current);
       // 不带引号的key范围
-      const range = createRange(current + 1, current + string.length)
+      const range = createRange(current + 1, current + string.length + 1)
       tokens.push(createToken({
         type: TokenTypes.String,
         range,
@@ -235,7 +235,7 @@ export default function parse(json: string): Visitor | null {
       const value = getFixedLiteral(json, current, literal)
       tokens.push(createToken({
         type: TokenTypes.FixedLiteral,
-        range: createRange(current, current + literal.length - 1),
+        range: createRange(current, current + literal.length),
         value
       }))
       current += literal.length

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,5 @@
+import { ComplexNode, SimpleNode } from "./node"
+
 interface CodeRange {
   start: number,
   end: number
@@ -26,4 +28,14 @@ function createError(...args: any[]): never {
   }
 }
 
-export { CodeRange, createRange, createError }
+const ComplexType = ['array', 'object']
+function isComplexNode(node: any): node is ComplexNode {
+  return node && ComplexType.includes(node.type)
+}
+
+const SimpleType = ['string', 'number', 'boolean', 'null']
+function isSimpleNode(node: any): node is SimpleNode {
+  return node && SimpleType.includes(node.type)
+}
+
+export { CodeRange, createRange, createError, isComplexNode, isSimpleNode }

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -1,23 +1,12 @@
-import { ComplexNode, NodeType, SimpleNode } from "./node";
-
-const ComplexType = ['array', 'object']
-const SimpleType = ['string', 'number', 'boolean', 'null']
+import { NodeType } from "./node";
 
 class Visitor {
   constructor(public body: NodeType) { }
 
-  isComplexNode(node: any): node is ComplexNode {
-    return node && ComplexType.includes(node.type)
-  }
+  get(keyPath?: string | string[]): NodeType | undefined {
+    if (keyPath === undefined) return this.body
 
-  isSimpleNode(node: any): node is SimpleNode {
-    return node && SimpleType.includes(node.type)
-  }
-
-  get(keyPath: string | string[]): NodeType | undefined {
     const path = Array.isArray(keyPath) ? keyPath : keyPath.trim().split('.')
-
-    if (path.length === 1 && path[0] === '') return this.body
 
     let node: NodeType | undefined = this.body
     for (let index = 0; index < path.length; index++) {


### PR DESCRIPTION
BREAKING CHANGE:
The coderange range is changed to end+1, Easier to use `string.slice(start, end)`
visitor.isSimpleNode/isComplexNode change to export
Fix the problem that the empty key node through visitor.get ('') cannot be obtained
Change the original visitor.get("") to visitor.get() to obtain the visitor.body node